### PR TITLE
Stop autoloading non-existent database/factories namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Rawilk\\HumanKeys\\": "src/",
-            "Rawilk\\HumanKeys\\Database\\Factories\\": "database/factories/"
+            "Rawilk\\HumanKeys\\": "src/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
Remove a remnant of the package skeleton template that autoloads database factories in composer.json. No factories are provided by this package, so the autoloading is not necessary.
