### PR TITLE
Add uuid generator

### DIFF
--- a/config/human-keys.php
+++ b/config/human-keys.php
@@ -13,6 +13,7 @@ return [
     | Supported:
     |    - ksuid (abc_p6UEyCc8D8ecLijAI5zVwOTP3D0)
     |    - snowflake (abc_1537200202186752)
+    |    - uuid (abc_b8a34e34553a41b885ae218ae81abd42)
     |
     | Note: Custom generators must implement the contract
     | Rawilk\HumanKeys\Contracts\Generator

--- a/src/Generators/UuidGenerator.php
+++ b/src/Generators/UuidGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\HumanKeys\Generators;
+
+use Illuminate\Support\Str;
+use Rawilk\HumanKeys\Contracts\Generator;
+
+class UuidGenerator implements Generator
+{
+    public function generate(?string $prefix = null): string
+    {
+        return implode('_', [
+            $prefix,
+            str_replace('-', '', Str::uuid()),
+        ]);
+    }
+}

--- a/tests/Unit/UuidGeneratorTest.php
+++ b/tests/Unit/UuidGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use Rawilk\HumanKeys\Generators\UuidGenerator;
+use Rawilk\HumanKeys\Tests\Fixture\Models\Post;
+
+beforeEach(function () {
+    config([
+        'human-keys.generator' => UuidGenerator::class,
+    ]);
+});
+
+it('can generate uuid ids for a model', function () {
+    $uuid = str_replace('-', '', (string) Str::uuid());
+
+    Str::createUuidsUsing(fn () => $uuid);
+
+    $post = Post::create(['name' => 'Example post']);
+
+    expect($post)
+        ->id->toBe("pos_{$uuid}");
+
+    Str::createUuidsNormally();
+});


### PR DESCRIPTION
PR adds a new `UuidGenerator` for generating ids with. This generator will use Laravel's `Str::uuid()` to generate a new id, and replace all `-` characters with an empty space.

An example id will look like: `abc_b8a34e34553a41b885ae218ae81abd42`

This generator will also remove the requirement to pull in an additional package to generate ids, as long as you set the config value to the new generator.
